### PR TITLE
Fix double-line separation under Linux

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ function returnParsedData(language, callback, err, data) {
 }
 
 function fromString(language, stringData) {
-    var segments = stringData.split("\n\n")
+    var segments = stringData.split((stringData.search("\n\r\n") != -1) ? "\n\r\n" : "\n\n" )
     return reduce(segments, createSrtData, language, [])
 }
 


### PR DESCRIPTION
It seems that, under my Linux system, with Node 0.8, the double-line separator is "\n\r\n" rather than "\n\n".
This solution works in both cases.
